### PR TITLE
Added trigger to allow actions before duplicate

### DIFF
--- a/src/templates/_widget.twig
+++ b/src/templates/_widget.twig
@@ -46,6 +46,7 @@
 
 {% js %}
 	$('#siteduplicate-duplicateButton').click(function(){
+		$(this).trigger('siteduplicate:duplicate');
 		$('input[name=action]').val('siteduplicate/duplicate');
 		$('#main-form').append('<input type="hidden" name="duplicateSiteId" value="'+$('#siteduplicate-siteId').val()+'"/>').val();
 		$('#main-form').submit();


### PR DESCRIPTION
Added jQuery trigger to allow actions before duplication of an entry. Use case: The Neo fields do not get duplicated if the hidden 'input.modified' field is set to false. Now it's possible to add a little logic to set the modified to true. Which means all the neo fields for the entry are also getting duplicated.